### PR TITLE
Fix ArchEthic service start issues, remove ScyllaDB deps

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,77 +1,42 @@
-#!/bin/sh
+#! /bin/bash
 set -e
 
-sed -i "s/tss/$(whoami)/gi" /etc/udev/rules.d/tpm-udev.rules
-udevadm control --reload-rules && udevadm trigger
+cp -a $SNAP/. $SNAP_DATA/
 
-update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64
+mkdir -p $SNAP_DATA/usr/lib/locale
 
-scylla_setup --no-raid-setup --no-ec2-check --no-kernel-check --no-verify-package --no-sysconfig-setup --io-setup=1 --no-version-check --no-cpuscaling-setup --no-fstrim-setup --no-memory-setup --no-swap-setup
+$SNAP/usr/sbin/locale-gen en_US.UTF-8
+$SNAP/usr/sbin/update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
 
-scylla_memory_setup --memory=8G
-scylla_cpuset_setup --cpuset 2
-
-systemctl start scylla-server
-
-cd $SNAP
+cd $SNAP_DATA
 seed=$(bin/archethic_node eval ":crypto.strong_rand_bytes(32)|>IO.inspect" | tr -d '\n')
 encoded_seed=$(bin/archethic_node eval "Base.encode16($seed)|>IO.inspect" | tr -d '\n')
-pub_key=$(bin/archethic_node eval "Tuple.to_list(ArchEthic.Crypto.generate_deterministic_keypair($seed))|>List.first|>IO.inspect" | tr -d '\n')
-encoded_pub_key=$(bin/archethic_node eval "Base.encode16($pub_key)|>IO.inspect" | tr -d '\n')
-cd -
+#pub_key=$(bin/archethic_node eval "Tuple.to_list(ArchEthic.Crypto.generate_deterministic_keypair($seed))|>List.first|>IO.inspect" | tr -d '\n')
+#encoded_pub_key=$(bin/archethic_node eval "Base.encode16($pub_key)|>IO.inspect" | tr -d '\n')
 
-ip=$(curl -s 'https://api64.ipify.org')
+#ip=$($SNAP_DATA/usr/bin/curl -s 'https://api64.ipify.org')
 
-sh -c 'cat > /etc/default/archethic.env' << EOF
+mkdir -p $SNAP_DATA/opt/data
 
-    ARCHETHIC_P2P_BOOTSTRAPPING_SEEDS=$ip:${encoded_pub_key//\"}
+mkdir -p $SNAP_DATA/etc/default
+
+cd $SNAP_DATA/etc/default
+
+bash -c 'cat > archethic.env' << EOF
+    LANG=en_US.UTF-8
+    LANGUAGE=en_US
+    LC_ALL=en_US.UTF-8
+    MIX_ENV=prod
+    ERLANG_COOKIE=$ERLANG_COOKIE
+    ARCHETHIC_P2P_BOOTSTRAPPING_SEEDS=54.39.179.91:30002:00011D967D71B2E135C84206DDD108B5925A2CD99C8EBC5AB5D8FD2EC9400CE3C98A:tcp
     ARCHETHIC_CRYPTO_SEED=${encoded_seed//\"}
     ARCHETHIC_NETWORK_TYPE=testnet
     ARCHETHIC_CRYPTO_NODE_KEYSTORE_IMPL=SOFTWARE
     ARCHETHIC_NODE_ALLOWED_KEY_ORIGINS=SOFTWARE
-    ARCHETHIC_BEACON_CHAIN_SLOT_TIMER_INTERVAL="*/10 * * * * *"
-    ARCHETHIC_BEACON_CHAIN_SUMMARY_TIMER_INTERVAL="0 * * * * *"
-    ARCHETHIC_ORACLE_CHAIN_POLLING_INTERVAL="*/10 * * * * *"
-    ARCHETHIC_ORACLE_CHAIN_SUMMARY_INTERVAL="50 * * * * *"
-    ARCHETHIC_SHARED_SECRETS_RENEWAL_SCHEDULER_INTERVAL="40 * * * * * *"
-    ARCHETHIC_SHARED_SECRETS_APPLICATION_INTERVAL="0 * * * * * *"
-    ARCHETHIC_SELF_REPAIR_SCHEDULER_INTRERVAL="5 * * * * * *"
-    ARCHETHIC_REWARD_SCHEDULER_INTERVAL="30 * * * * *"
+    ARCHETHIC_NETWORKING_IMPL=IPFY
+    ARCHETHIC_NETWORKING_PORT_FORWARDING=false
+    ARCHETHIC_MUT_DIR=$SNAP_DATA/opt/data
 EOF
 
-sh -c 'cat > /etc/systemd/system/archethic.service' << EOF
+cd -
 
-    [Unit]
-    Description=ARCHEthic service
-    After=local-fs.target network.target
-
-    [Service]
-    Type=simple
-    User=$USER
-    Group=$USER
-
-    WorkingDirectory=$SNAP
-
-    ExecStart=$SNAP/bin/archethic_node foreground
-    ExecStop=$SNAP/bin/archethic_node stop
-
-    EnvironmentFile=/etc/default/archethic.env
-    Environment=LANG=en_US.utf8
-    Environment=MIX_ENV=prod
-    Environment=ERLANG_COOKIE=$ERLANG_COOKIE
-
-    Restart=on-failure
-    RemainAfterExit=yes
-    RestartSec=5
-
-    LimitNOFILE=65535
-    UMask=0027
-    SyslogIdentifier=archethic
-
-    [Install]
-    WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable archethic
-systemctl start archethic

--- a/snap/local/set-config
+++ b/snap/local/set-config
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+cd $SNAP_DATA
+
+export $(grep -v '^#' etc/default/archethic.env | xargs -d '\n')
+
+#ip=$($SNAP_DATA/usr/bin/curl -s 'https://api64.ipify.org)
+
+export ARCHETHIC_BEACON_CHAIN_SLOT_TIMER_INTERVAL="*/10 * * * * *"
+export ARCHETHIC_BEACON_CHAIN_SUMMARY_TIMER_INTERVAL="0 * * * * *"
+export ARCHETHIC_ORACLE_CHAIN_POLLING_INTERVAL="*/10 * * * * *"
+export ARCHETHIC_ORACLE_CHAIN_SUMMARY_INTERVAL="0 * * * * *"
+export ARCHETHIC_SHARED_SECRETS_RENEWAL_SCHEDULER_INTERVAL="40 * * * * * *"
+export ARCHETHIC_SHARED_SECRETS_APPLICATION_INTERVAL="0 * * * * * *"
+export ARCHETHIC_SELF_REPAIR_SCHEDULER_INTRERVAL="5 * * * * * *"
+export ARCHETHIC_REWARD_SCHEDULER_INTERVAL="30 * * * * *"
+
+cd -
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,28 +41,29 @@ package-repositories:
     suites: [focal]
     key-id: 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA
     url: https://packages.erlang-solutions.com/ubuntu
-  - type: apt
-    architectures: [amd64]
-    formats: [deb]
-    components: [multiverse]
-    suites: [focal]
-    key-server: hkp://keyserver.ubuntu.com:80
-    key-id: 7752A0722F457FB76C0F44985E08FBD8B5D6EC9C
-    url: http://downloads.scylladb.com/downloads/scylla/deb/ubuntu/scylladb-4.3
 
 apps:
   archethic-node:
-    command: bin/archethic_node foreground
+    daemon: simple
+    command-chain:
+      - bin/set-config
+    command: bin/archethic_node_start
+    stop-command: bin/archethic_node_stop
+    refresh-mode: endure
+    plugs:
+      - network
+      - network-bind
+      - tpm
 
-plugs:
-  config-system:
-   interface: system-files
-   write:
-     - /etc
-
-hooks:
-  install:
-    plugs: [network,network-bind,hardware-observe,config-system]
+layout:
+  /usr/lib/locale:
+    bind: $SNAP_DATA/usr/lib/locale
+  /usr/share/i18n/SUPPORTED:
+    symlink: $SNAP/usr/share/i18n/SUPPORTED
+  /usr/share/i18n/locales:
+    symlink: $SNAP/usr/share/i18n/locales
+  /usr/share/i18n/charmaps:
+    symlink: $SNAP/usr/share/i18n/charmaps
 
 parts:
   archethic-node:
@@ -112,18 +113,18 @@ parts:
       - LDFLAGS: ''
       - PKG_CONFIG_PATH: ''
     stage-packages:
+      - locales
       - esl-erlang
       - elixir
       - openssl
-      - scylla
-      - openjdk-8-jre-headless
       - libsodium23
+      - tpm2-tools 
       - libwxgtk-webview3.0-gtk3-0v5
       - libglu1-mesa
-      - unixodbc-dev
-      - tpm2-tools
+      - unixodbc-dev 
     override-build: |
       locale-gen en_US.UTF-8
+      update-locale LC_ALL=en_US.UTF-8
       wget https://github.com/tpm2-software/tpm2-tss/releases/download/3.1.0/tpm2-tss-3.1.0.tar.gz
       tar -xf tpm2-tss-3.1.0.tar.gz --one-top-level=tpm2-tss --strip-components 1
       cd tpm2-tss
@@ -154,3 +155,16 @@ parts:
       wait $!
       VERSION=$(grep 'version:' mix.exs | cut -d '"' -f2)
       tar zxvf _build/prod/rel/archethic_node/releases/$VERSION/archethic_node.tar.gz -C $SNAPCRAFT_PART_INSTALL/
+      echo '#! /bin/bash' >$SNAPCRAFT_PART_INSTALL/bin/archethic_node_start
+      echo '' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_start
+      echo 'cd $SNAP_DATA' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_start
+      echo 'bin/archethic_node foreground' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_start
+      echo 'exec "$@"' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_start
+      chmod +x $SNAPCRAFT_PART_INSTALL/bin/archethic_node_start
+      echo '#! /bin/bash' >$SNAPCRAFT_PART_INSTALL/bin/archethic_node_stop
+      echo '' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_stop
+      echo 'cd $SNAP_DATA' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_stop
+      echo 'bin/archethic_node stop' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_stop
+      echo 'exec "$@"' >>$SNAPCRAFT_PART_INSTALL/bin/archethic_node_stop
+      chmod +x $SNAPCRAFT_PART_INSTALL/bin/archethic_node_stop
+      cp -p $SNAPCRAFT_PROJECT_DIR/snap/local/set-config $SNAPCRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
Resolves #6
Removes ScyllaDB deps
Removes OpenJDK deps

### Platform: Linux

Refer README.md for initial Snapcraft dev setup. 

## Test instructions:
- [x] Build the project by running `snapcraft snap --use-lxd --debug`
- [x] Uninstall existing archethic-node snap by running `sudo snap remove archethic-node --purge`
- [x] Make sure ports (30002,40000) are forwarded from router and scylladb is installed in host machine.
- [x] Install the project by running `sudo snap install --devmode archethic-node_0.1_amd64.snap`.
- [x] If the archethic explorer is accessible at {public_ip}:40000, check this box and approve. 
- [x] Otherwise submit feedback