### PR TITLE
Add node env variables customisation, Fix archethic-foundation/archethic-snap#22

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+http_port="$(snapctl get ports.http)"
+p2p_port="$(snapctl get ports.p2p)"
+
+if [ -z "$http_port" ]; then
+    http_port=40000
+fi
+if [ -z "$p2p_port" ]; then
+    p2p_port=30002
+fi
+
+cd $SNAP_DATA/etc/default
+
+bash -c 'cat > archethic.env' << EOF
+    ARCHETHIC_HTTP_PORT=$http_port
+    ARCHETHIC_P2P_PORT=$p2p_port
+    LANG=en_US.UTF-8
+    LANGUAGE=en_US
+    LC_ALL=en_US.UTF-8
+    MIX_ENV=prod
+    ERLANG_COOKIE=$ERLANG_COOKIE
+    ARCHETHIC_P2P_BOOTSTRAPPING_SEEDS=54.39.179.91:30002:00011D967D71B2E135C84206DDD108B5925A2CD99C8EBC5AB5D8FD2EC9400CE3C98A:tcp
+    ARCHETHIC_CRYPTO_SEED=${encoded_seed//\"}
+    ARCHETHIC_CRYPTO_NODE_KEYSTORE_IMPL=SOFTWARE
+    ARCHETHIC_NODE_ALLOWED_KEY_ORIGINS=SOFTWARE
+    ARCHETHIC_NETWORKING_IMPL=IPFY
+    ARCHETHIC_NETWORKING_PORT_FORWARDING=false
+    ARCHETHIC_NETWORK_TYPE=testnet
+    ARCHETHIC_MUT_DIR=$SNAP_DATA/opt/data
+
+EOF

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,10 +3,10 @@ set -e
 
 cp -a $SNAP/. $SNAP_DATA/
 
-mkdir -p $SNAP_DATA/usr/lib/locale
+# mkdir -p $SNAP_DATA/usr/lib/locale
 
-$SNAP/usr/sbin/locale-gen en_US.UTF-8
-$SNAP/usr/sbin/update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
+# $SNAP/usr/sbin/locale-gen en_US.UTF-8
+# $SNAP/usr/sbin/update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
 
 cd $SNAP_DATA
 seed=$(bin/archethic_node eval ":crypto.strong_rand_bytes(32)|>IO.inspect" | tr -d '\n')
@@ -30,11 +30,11 @@ bash -c 'cat > archethic.env' << EOF
     ERLANG_COOKIE=$ERLANG_COOKIE
     ARCHETHIC_P2P_BOOTSTRAPPING_SEEDS=54.39.179.91:30002:00011D967D71B2E135C84206DDD108B5925A2CD99C8EBC5AB5D8FD2EC9400CE3C98A:tcp
     ARCHETHIC_CRYPTO_SEED=${encoded_seed//\"}
-    ARCHETHIC_NETWORK_TYPE=testnet
     ARCHETHIC_CRYPTO_NODE_KEYSTORE_IMPL=SOFTWARE
     ARCHETHIC_NODE_ALLOWED_KEY_ORIGINS=SOFTWARE
     ARCHETHIC_NETWORKING_IMPL=IPFY
     ARCHETHIC_NETWORKING_PORT_FORWARDING=false
+    ARCHETHIC_NETWORK_TYPE=testnet
     ARCHETHIC_MUT_DIR=$SNAP_DATA/opt/data
 EOF
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,8 @@
-name: archethic-node # you probably want to 'snapcraft register <name>'
-base: core20 # the base snap is the execution environment for this snap
-version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+name: archethic
+base: core20
 summary: Official ArchEthic blockchain node software
 description: |
-  Welcome to the ArchEthic Node! This tool enables you to install and run an ArchEthic node. ArchEthic is a next generation of blockchain focused on rapid scalability and easy accessibility.
+  Welcome to ArchEthic blockchain. This tool enables you to install and run an ArchEthic node. ArchEthic is a next generation of blockchain focused on rapid scalability and easy accessibility.
     
   ArchEthic features:
 
@@ -28,8 +27,9 @@ description: |
 
     ArchEthic Foundation
     https://www.archethic.net
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+grade: stable 
+confinement: strict # use 'strict' once you have the right plugs and slots
+adopt-info: archethic-node
 architectures:
   - build-on: amd64
     run-on: amd64
@@ -49,6 +49,7 @@ apps:
       - bin/set-config
     command: bin/archethic_node_start
     stop-command: bin/archethic_node_stop
+    install-mode: disable
     refresh-mode: endure
     plugs:
       - network
@@ -69,7 +70,7 @@ parts:
   archethic-node:
     plugin: dump
     source: https://github.com/archethic-foundation/archethic-node.git
-    source-branch: master
+    source-tag: 'v0.13.1'
     source-type: git
     build-packages:
       - locales
@@ -123,6 +124,7 @@ parts:
       - libglu1-mesa
       - unixodbc-dev 
     override-build: |
+      snapcraftctl set-version "$(git describe --abbrev=0)"
       locale-gen en_US.UTF-8
       update-locale LC_ALL=en_US.UTF-8
       wget https://github.com/tpm2-software/tpm2-tss/releases/download/3.1.0/tpm2-tss-3.1.0.tar.gz


### PR DESCRIPTION
## Changelog:

Added configure hook to customise ports (ARCHETHIC_HTTP_PORT, ARCHETHIC_P2P_PORT)
Disabled archethic-node serivce autostart
Pulling from archethic-node v0.13.1 release tag

### Platform: Linux

Refer README.md for initial Snapcraft dev setup. 

## Test instructions:
- [x] Clean previous build cache `snapcraft clean archethic-node --use-lxd`
- [x] Build the project by running `snapcraft --use-lxd --debug`
- [x] Uninstall existing archethic-node snap by running `sudo snap remove archethic-node --purge`
- [x] Make sure ports (30003,40001) are forwarded from router and scylladb is installed in host machine.
- [x] Install the project by running `sudo snap install --devmode archethic-node_0.1_amd64.snap`.
- [x] Verify archethic-node serivice is inactive `sudo snap services archethic`.
- [x] Pass custom HTTP port `sudo snap set archethic ports.http=40001`.
- [x] Pass custom P2P port `sudo snap set archethic ports.p2p=30003`.
- [x] Start archethic node service `sudo snap start archethic`.
- [x] Open a shell to the running service `sudo snap run --shell archethic.archethic-node`.
- [x] Verify the values of ARCHETHIC_HTTP_PORT=40001 and ARCHETHIC_P2P_PORT=30003 by running `printenv`.
- [x] If the archethic explorer is accessible at {public_ip}:40001, check this box and approve. Uninstall existing snap by running `sudo snap remove archethic --purge`.
- [ ] Otherwise submit feedback.

