### PR TITLE
Check user-defined ports are available and in range, Closes archethic-foundation/archethic-snap#23

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -4,10 +4,40 @@ http_port="$(snapctl get ports.http)"
 p2p_port="$(snapctl get ports.p2p)"
 
 if [ -z "$http_port" ]; then
-    http_port=40000
+    logger -t ${SNAP_NAME} "WARNING: ports.http is not set"
 fi
+
 if [ -z "$p2p_port" ]; then
-    p2p_port=30002
+    logger -t ${SNAP_NAME} "WARNING: ports.p2p is not set"
+fi
+
+if [ -z "$http_port" ] && [ -z "$p2p_port" ]; then
+    exit 0
+fi
+
+if [ "$http_port" -eq "$p2p_port" ]; then
+    echo "ports.http and ports.p2p cannot be same"
+    exit 1
+fi
+
+(nc -z 0.0.0.0 $http_port)
+port_status=$?
+if [ "$http_port" -lt "32768" ] || [ "$http_port" -gt "60999" ]; then
+    echo "Port $http_port is invalid. Make sure it is within range [32768-60999]"
+    exit 1
+elif [ "$port_status" -eq "0" ]; then
+    echo "Port $http_port is not available. Please try different port within range [32768-60999]"
+    exit 1
+fi
+
+(nc -z 0.0.0.0 $p2p_port)
+port_status=$?
+if [ "$p2p_port" -lt "32768" ] || [ "$p2p_port" -gt "60999" ]; then
+    echo "Port $p2p_port is invalid. Make sure it is within range [32768-60999]"
+    exit 1
+elif [ "$port_status" -eq "0" ]; then
+    echo "Port $p2p_port is not available. Please try different port within range [32768-60999]"
+    exit 1
 fi
 
 cd $SNAP_DATA/etc/default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ description: |
 
     ArchEthic Foundation
     https://www.archethic.net
-grade: stable 
+grade: stable
 confinement: strict # use 'strict' once you have the right plugs and slots
 adopt-info: archethic-node
 architectures:


### PR DESCRIPTION
## Changelog:

Added check if the ports are within unprivileged port range (32768-60999)
Added check if the ports are available using netcat

### Platform: Linux

Refer README.md for initial Snapcraft dev setup. 

## Test instructions:
- [x] Clean previous build cache `snapcraft clean archethic-node --use-lxd`.
- [x] Build the project by running `snapcraft --use-lxd --debug`.
- [x] Uninstall existing archethic-node snap by running `sudo snap remove archethic-node --purge`.
- [x] Make sure ports (33000,40000) are forwarded from router and scylladb is installed in host machine.
- [x] Install the project by running `sudo snap install --devmode archethic_v0.13.0_amd64.snap`. This shouldn't print any error.
- [x] Verify archethic-node serivice is inactive `sudo snap services archethic`.
- [x] Pass custom HTTP port `sudo snap set archethic ports.http=400`. Check if correct error message is printed.
- [x] Pass custom P2P port `sudo snap set archethic ports.p2p=300`. Check if correct error message is printed.
- [x] Pass custom HTTP port `sudo snap set archethic ports.http=40000` and custom P2P port `sudo snap set archethic ports.p2p=40000`. Check if correct error message is printed.
- [x] Pass custom HTTP port `sudo snap set archethic ports.http=40000`. This shouldn't print any error.
- [x] Pass custom HTTP port `sudo snap set archethic ports.p2p=33000` This shouldn't print any error.
- [x] Start archethic node service `sudo snap start archethic`.
- [x] Open a shell to the running service `sudo snap run --shell archethic.archethic-node`.
- [x] Verify the values of ARCHETHIC_HTTP_PORT=40000 and ARCHETHIC_P2P_PORT=33000 by running `printenv`.
- [x] If the archethic explorer is accessible at {public_ip}:40000, check this box and approve. Uninstall existing snap by running `sudo snap remove archethic --purge`.
- [ ] Otherwise submit feedback.

