### PR TITLE
Pull from archethic-node develop branch; Closes archethic-foundation/archethic-snap#26

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ parts:
   archethic-node:
     plugin: dump
     source: https://github.com/archethic-foundation/archethic-node.git
-    source-tag: 'v0.13.1'
+    source-branch: 'develop'
     source-type: git
     build-packages:
       - locales


### PR DESCRIPTION
## Changelog

Changed to develop as source-branch

### Platform: Linux

Refer README.md for initial Snapcraft dev setup. 

## Test instructions:
- [x] Clean previous build cache `snapcraft clean archethic-node --use-lxd`.
- [x] Build the project by running `snapcraft --use-lxd --debug`.
- [x] Uninstall existing archethic-node snap by running `sudo snap remove archethic-node --purge`.
- [x] Make sure ports (33000,40000) are forwarded from router and scylladb is installed in host machine.
- [x] Install the project by running `sudo snap install --devmode archethic_v0.13.0_amd64.snap`. This shouldn't print any error.
- [x] Verify archethic-node serivice is inactive `sudo snap services archethic`.
- [x] Pass custom HTTP port `sudo snap set archethic ports.http=40000`. This shouldn't print any error.
- [x] Pass custom HTTP port `sudo snap set archethic ports.p2p=33000` This shouldn't print any error.
- [x] Start archethic node service `sudo snap start archethic`.
- [x] If the archethic explorer is accessible at {public_ip}:40000, check this box and approve. Uninstall existing snap by running `sudo snap remove archethic --purge`.
- [ ] Otherwise submit feedback.